### PR TITLE
Switch PyPI badge to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![latest version](https://badge.fury.io/py/porousmedialab.svg)](https://badge.fury.io/py/porousmedialab)
+[![PyPI version](https://img.shields.io/pypi/v/porousmedialab.svg)](https://pypi.org/project/porousmedialab/)
 [![GitHub issues](https://img.shields.io/github/issues/biogeochemistry/PorousMediaLab.svg)](https://github.com/biogeochemistry/PorousMediaLab/issues)
 [![GitHub forks](https://img.shields.io/github/forks/biogeochemistry/PorousMediaLab.svg)](https://github.com/biogeochemistry/PorousMediaLab/network/members)
 [![GitHub stars](https://img.shields.io/github/stars/biogeochemistry/PorousMediaLab.svg)](https://github.com/biogeochemistry/PorousMediaLab/stargazers)


### PR DESCRIPTION
## Summary
Replace badge.fury.io with shields.io for the PyPI version badge to fix caching issues showing outdated version.

### Changes
- Switch PyPI badge from badge.fury.io to img.shields.io
- Update link to point to PyPI project page

## Test Plan
- [ ] Verify badge displays correct version (2.1.0)
- [ ] Confirm badge links to PyPI project page