### PR TITLE
release: v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-06-03
+
 ### Added
 - Input validation for numerical stability:
   - Division-by-zero guards in `desolver.py` (dx, phi, diff_coef)
@@ -14,11 +16,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Henry's constant validation in `equilibriumsolver.py`
 - CFL stability warning when coefficient exceeds 0.25
 
+### Changed
+- Behavior-preserving structural refactor of the core solver and class contracts (ODE integration output is bit-for-bit identical):
+  - Replaced string-based boundary-condition handling in `desolver.py` with a `BoundaryConditionType` enum (public string API and constant/flux aliases preserved)
+  - Decomposed `ode_integrate` into focused module-level helpers (`_k_loop`, `_rk4_step`, `_butcher5_step`)
+  - De-duplicated `Column` top/bottom flux estimators and unified `Batch`/`Column` acid-base concentration updates into `Lab`
+  - Moved `Batch`/`Column` plotter aliases into mixins in `plotting_mixins.py`
+
 ### Fixed
 - Global namespace pollution in `lab.py` when using `exec()` for rate functions
 
 ### Removed
 - `sensitivity.py` module (contained only unimplemented stubs)
+- Dead `element.py` module and legacy Python 2 compatibility code
 
 ### Tests
 - Added comprehensive tests for all new input validation
@@ -31,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Column transport with Dirichlet BCs
   - Advection pulse transport
   - Timestep convergence
+- Characterization, golden-value, and contract tests added alongside the refactor (test suite now 389 passing)
 
 ## [2.1.0] - 2026-01-30
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@
 
 The toolbox for batch and 1D reactive transport modelling in porous media aimed at the easiness of use for the user without computational background.
 
+## What's New in v2.2.0
+
+**Robustness and maintainability** improvements with expanded test coverage:
+
+- Input validation across the solver: division-by-zero guards and a CFL stability warning catch unstable grids early
+- Behavior-preserving refactor of the core ODE/PDE solver and class contracts (boundary conditions, flux estimators, acid-base updates)
+- Removed unused code (`sensitivity.py` stubs, dead `element.py`, legacy Python 2 compatibility)
+- Test suite expanded to 389 tests, including mathematical-correctness integration tests
+
 ## What's New in v2.1.1
 
 **Correctness and packaging hardening** for solver setup and release artifacts:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "porousmedialab"
-version = "2.1.1"
+version = "2.2.0"
 description = "Toolbox for batch and 1D reactive transport modeling in porous media aimed on easiness of use for the user without computational background"
 authors = ["Igor Markelov <is.markelov@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
## Release v2.2.0

Prepares the v2.2.0 release: version bump + changelog/README updates. No source-code changes beyond version metadata — the features and refactors landed in earlier commits on this branch.

### Changes in this release
- **Added** — numerical-stability input validation (division-by-zero guards in `desolver.py` / `metrics.py`, Henry's-constant validation in `equilibriumsolver.py`) and a CFL stability warning when the diffusion coefficient exceeds 0.25.
- **Changed** — behavior-preserving structural refactor of the core solver and class contracts (`BoundaryConditionType` enum, decomposed `ode_integrate`, de-duplicated `Column` flux estimators, `plotting_mixins.py`). ODE output is bit-for-bit identical.
- **Fixed** — global namespace pollution in `lab.py` when `exec()`-ing rate functions.
- **Removed** — `sensitivity.py` (unimplemented stubs), dead `element.py`, and legacy Python 2 compatibility code.
- **Tests** — suite expanded to **389 passing** (input-validation, blackbox optimization, integration/correctness, characterization & golden-value tests).

### Verification
- `poetry run pytest tests/` → 389 passed
- `poetry build` → sdist + wheel build cleanly; removed modules confirmed absent from the wheel

### Post-merge release steps
After merge to `master`:
```
git tag -a v2.2.0 -m "v2.2.0"
git push origin v2.2.0
make publish   # poetry publish → PyPI (irreversible)
```